### PR TITLE
fixing typo in About page

### DIFF
--- a/templates/about.tmp
+++ b/templates/about.tmp
@@ -5,7 +5,7 @@
 
 <p><img src="https://snap.berkeley.edu/comp09/forbanner.png"/></p>
 
-<p>Snap<em>!</em> runs in your browser. It is implemented using Javascript, which is designed to limit the ability of browser-based software to affect your computer outside of Snap<i>!</i> itself, so it’s safe to run even other people’s projects, even if you don’t trust our competence or good intentions.  (Our lawyers make us say we offer NO WARRANTY; see our <a href="/tos>Terms of Service</a>.)</p> 
+<p>Snap<em>!</em> runs in your browser. It is implemented using Javascript, which is designed to limit the ability of browser-based software to affect your computer outside of Snap<i>!</i> itself, so it’s safe to run even other people’s projects, even if you don’t trust our competence or good intentions.  (Our lawyers make us say we offer NO WARRANTY; see our <a href="/tos">Terms of Service</a>.)</p> 
 
 <p>Snap<em>!</em> is presented by the University of California at Berkeley. It is developed by Jens Mönig at SAP, with design input and documentation by Brian Harvey at UC Berkeley, and contributions by students at UC Berkeley and elsewhere.</p>
 


### PR DESCRIPTION
Just fixing _About_ page. Issue reported from Snap! forum