### PR TITLE
Add overflow, white-space and text-overflow CSS elements to project page to project page for remix author and original project name

### DIFF
--- a/static/style/project.css
+++ b/static/style/project.css
@@ -190,10 +190,16 @@ img.collection-thumbnail {
     right: 0;
     bottom: .4em;
     font-size: 0.8em;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .remixed-from .author {
     font-size: 1em;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;    
 }
 
 .embed {


### PR DESCRIPTION
### Resolves

Partially #90.

### Changes

Add overflow, white-space and text-overflow CSS elements to project page to project page for remix author and original project name.

### Cause of Changes

As described in #90, the website overflows in case of a big username and project name. I do not know which CSS class is for what but you could use these elements to fix the overflow issue in other places.