### PR TITLE
Remove position: absolute

### DIFF
--- a/static/style/project.css
+++ b/static/style/project.css
@@ -171,7 +171,6 @@ img.collection-thumbnail {
 }
 
 .project .author {
-    position: absolute;
     line-height: 4em;
     margin-left: 1em;
 }


### PR DESCRIPTION
This was causing unusual positioning and kind of broke the website by moving the project author's name under the thumbnail of the project under it in the next line on different devices. This has been reported [here](https://forum.snap.berkeley.edu/t/snap-is-broken-it-looks-weird-and-i-cannot-get-it-fixed/4257).
### Test Coverage
Manually tested with Chrome Dev Tools on Windows 10. Here are some screenshots-
Homepage:
Before:
![image](https://user-images.githubusercontent.com/61620631/98464846-c7ec8900-21ef-11eb-89bc-2d9c35a17ced.png)
After:
![image](https://user-images.githubusercontent.com/61620631/98464899-2b76b680-21f0-11eb-9116-2179637290d8.png)
Search:
Before:
![image](https://user-images.githubusercontent.com/61620631/98464937-53feb080-21f0-11eb-9d4b-792953a04b05.png)
After:
![image](https://user-images.githubusercontent.com/61620631/98464965-6d9ff800-21f0-11eb-932d-dc3df658f70d.png)

### Alternatives
Instead of removing the property, its value could be changed to any of sticky, inherit, initial, relative, revert and unset, too and that would have the same effect; but I could not find why it would be necessary.