### PR TITLE
Ability for New tab when clicking a Snap! project

### DIFF
--- a/static/js/project.js
+++ b/static/js/project.js
@@ -20,17 +20,39 @@ function itemDiv (item, itemType, ownerUsernamePath, nameField,
             '"></i>'
     }
 
+    
+    var project_href_url =
+        itemType + '?user=' + encodeURIComponent(eval('item.' + ownerUsernamePath)) +
+        '&' + itemType + '=' + encodeURIComponent(item[nameField]);
+        
+    var target = 'target="_self"';
+
+    if (options.linkTarget) {
+        if (options.linkTarget == "_blank") {
+            target = 'target="_blank" rel="noopener noreferrer"';
+        } else {
+            target = 'target="' + options.linkTarget + '"';
+        }
+    }
+
+    var html_a_start_tag =
+        '<a ' +
+            target +
+            ' ' +
+            'href="' + project_href_url + '"' +
+        '>';
+
     div.innerHTML +=
-        '<a target="' + (options.linkTarget || '_self')
-        + '" href="' + itemType +
-        '?user=' + encodeURIComponent(eval('item.' + ownerUsernamePath)) +
-        '&' + itemType + '=' + encodeURIComponent(item[nameField]) +
-        '"><img class="thumbnail" alt="' +
-        (item.thumbnail ? escapeHtml(item[nameField]) : '') +
-        '" title="' + escapeHtml(item[descriptionField]) +
-        (item.thumbnail ? '" src="' + escapeHtml(item.thumbnail)  + '"' : '') +
-        '"><span class="' + itemType + '-name">' + escapeHtml(item[nameField]) +
-        '</span></a>';
+        html_a_start_tag +
+            '<img class="thumbnail" alt="' +
+                (item.thumbnail ? escapeHtml(item[nameField]) : '') +
+                '" title="' + escapeHtml(item[descriptionField]) +
+                (item.thumbnail ? '" src="' + escapeHtml(item.thumbnail)  + '"' : '') +
+            '">' +
+            '<span class="' + itemType + '-name">' +
+                escapeHtml(item[nameField]) +
+            '</span>' +
+        '</a>';
 
     if (extraFields) {
         Object.keys(extraFields).forEach(function (fieldName) {

--- a/templates/collection.tmp
+++ b/templates/collection.tmp
@@ -90,8 +90,7 @@
                                             isPublished: 'ispublished',
                                             author: 'username'
                                         },
-                                        withCollectionControls: true,
-                                        linkTarget: '_blank'
+                                        withCollectionControls: true
                                     }
                                 )
                             );

--- a/templates/collection.tmp
+++ b/templates/collection.tmp
@@ -90,7 +90,8 @@
                                             isPublished: 'ispublished',
                                             author: 'username'
                                         },
-                                        withCollectionControls: true
+                                        withCollectionControls: true,
+                                        linkTarget: '_blank'
                                     }
                                 )
                             );


### PR DESCRIPTION
Among the "options" input when calling "newProjectDiv" or "newCollectionDiv" from cloud.js, add this line to enable:
`linkTarget: '_blank'`

Tested in `collection.tmp` so far

Will use a secure version of a New Tab as written here: https://www.freecodecamp.org/news/how-to-use-html-to-open-link-in-new-tab/

Example:
![image](https://user-images.githubusercontent.com/29664484/116366844-92e2eb80-a7bb-11eb-9525-808715155fa0.png)
