### PR TITLE
Convert SQL Time to ISO 8601, Safari Time Support

### DIFF
--- a/static/js/base.js
+++ b/static/js/base.js
@@ -219,7 +219,16 @@ function doneLoading (selector) {
 // Other goodies
 
 function formatDate (dateString) {
-    return (new Date(dateString + ':00')).toLocaleString(
+    dateString = dateString + ':00';
+        
+    // Replaces the first instance of a space,
+    //  and replace with "T" to fit ISO 8601,
+    //  which all modern browsers support
+    // Example: YYYY-MM-DD HH:MM:SS-TZ:tz --> YYYY-MM-DDTHH:MM:SS-TZ:tz
+    //  Note: TZ:tz is Hour and Minutes of Time Zone
+    dateString = dateString.replace(' ', 'T');
+    
+    return (new Date(dateString)).toLocaleString(
         localizer.locale || 'en-us',
         { month: 'long', day: 'numeric', year: 'numeric' }
     );


### PR DESCRIPTION
Safari had a problem supporting the time format outputted by the SQL Server through Lua

Safari's JavaScript interpreter for the Date class doesn't support the SQL Server format: YYYY-MM-DD HH:MM:SS-TZ:tz (where TZ:tz is Hour and Minutes of Time Zone)

We can luckily convert this time to the ISO 8601 time string format easily: YYYY-MM-DDTHH:MM:SS-TZ:tz, where "T" is between the date and time+timezone in the string 

We replace the first space in the time string with "T", which is between the date and time+timezone in the string

There's no expectation for the user to modify this or any other part of the code to modify this, so the input format can be assumed to be the same